### PR TITLE
Highlight the hovered turbo-frame with secondary color

### DIFF
--- a/vendor/assets/stylesheets/hotwire-debug.scss
+++ b/vendor/assets/stylesheets/hotwire-debug.scss
@@ -1,10 +1,12 @@
 :root {
   --color-highlight: rgba(255, 232, 1, 1);
   --color-main: rgba(95, 206, 214, 1);
+  --color-secondary: rgba(239, 107, 170, 1);
 }
 :root[data-hotwire-scheme-dark] {
   --color-highlight: rgba(200, 200, 200, 1);
   --color-main: rgba(0, 0, 0, 1);
+  --color-secondary: rgba(55, 0, 179, 1);
 }
 #hotwire-toggle {
   height: 2rem;
@@ -42,11 +44,11 @@
     padding-top: 1rem;
     transition: all ease-in-out 0.3s;
     &:hover {
-      display: block;
       position: relative;
+      border-color: var(--color-secondary) !important;
 
       &:after {
-        color: var(--color-main) !important;
+        color: var(--color-secondary) !important;
         content: attr(id);
         display: block;
         font-weight: bold;
@@ -68,7 +70,7 @@
       box-shadow: unset;
     }
     50% {
-      box-shadow:inset 0 0 4rem var(--color-main);
+      box-shadow:inset 0 0 4rem var(--color-highlight);
     }
     100% {
       box-shadow: unset;


### PR DESCRIPTION
🚧 Highlight the hovered turbo-frame with secondary color

Looked cute, may delete later.